### PR TITLE
Fix bug in `README logo`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Astro Docs <img align="right" valign="center" height="52" width="39" src="https://raw.githubusercontent.com/withastro/astro/main/assets/brand/logo.svg" alt="Astro logo" />
+# Astro Docs <img align="right" valign="center" height="52" width="39" src="https://astro.build/assets/press/astro-icon-light.svg" alt="Astro logo" />
 
 To all who come to this happy place: welcome.
 


### PR DESCRIPTION
I have changed the README image as it was not working.
![docs-README-md](https://user-images.githubusercontent.com/106132925/224856773-93d0a2d1-c198-48e8-81f4-33d5c86057a1.png)
